### PR TITLE
fix: Set/SetMulti panic on a freshly built record

### DIFF
--- a/setter.go
+++ b/setter.go
@@ -37,6 +37,7 @@ func (db database) Set(ctx context.Context, record dal.Record) (err error) {
 	if docRef == nil {
 		return fmt.Errorf("keyToDocRef is nil for key=%v", key)
 	}
+	record.SetError(nil) // see transaction.Set: avoid record.Data() panic on a fresh record
 	data := record.Data()
 	_, err = setFirestore(ctx, docRef, data)
 	return err
@@ -51,6 +52,7 @@ func (db database) SetMulti(ctx context.Context, records []dal.Record) (err erro
 	for _, record := range records {
 		key := record.Key()
 		docRef := keyToDocRef(key, db.client)
+		record.SetError(nil) // see transaction.Set: avoid record.Data() panic on a fresh record
 		data := record.Data()
 		if _, err = batch.Set(docRef, data); err != nil {
 			break

--- a/setter_test.go
+++ b/setter_test.go
@@ -1,0 +1,42 @@
+package dalgo2firestore
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+
+	"github.com/dal-go/dalgo/dal"
+)
+
+// Test_DB_Set_does_not_panic_on_fresh_record is the regression for the bug where
+// database.Set called record.Data() on a freshly built NewRecordWithData record
+// (whose error is still nil), and record.Data() panics with "an attempt to
+// access record data before it was retrieved from database and SetError(error)
+// called". Set must mark the record error first (like the insert() path does),
+// so writing a brand-new record succeeds. This broke every eventus store write
+// (e.g. create-event) against Firestore.
+func Test_DB_Set_does_not_panic_on_fresh_record(t *testing.T) {
+	origKeyToDocRef := keyToDocRef
+	origSet := setFirestore
+	defer func() { keyToDocRef = origKeyToDocRef; setFirestore = origSet }()
+
+	keyToDocRef = func(_ *dal.Key, _ *firestore.Client) *firestore.DocumentRef {
+		return &firestore.DocumentRef{ID: "x"}
+	}
+	called := 0
+	setFirestore = func(_ context.Context, _ *firestore.DocumentRef, _ interface{}) (*firestore.WriteResult, error) {
+		called++
+		return &firestore.WriteResult{}, nil
+	}
+
+	db := database{id: "db", client: &firestore.Client{}}
+	// A freshly built record: NewRecordWithData leaves the record error nil.
+	rec := dal.NewRecordWithData(dal.NewKeyWithID("c", "1"), &struct{ V string }{V: "v"})
+	if err := db.Set(context.Background(), rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called != 1 {
+		t.Fatalf("expected setFirestore to be called once, got %d", called)
+	}
+}

--- a/transaction.go
+++ b/transaction.go
@@ -124,6 +124,11 @@ func (tx transaction) Set(ctx context.Context, record dal.Record) (err error) {
 	}
 	key := record.Key()
 	dr := keyToDocRef(key, tx.db.client)
+	record.SetError(nil) // Mark record as not having an error so record.Data()
+	// does not panic on a freshly built (NewRecordWithData) record whose error
+	// is still nil. Mirrors SetMulti below and the insert() path; without it
+	// Set panics with "an attempt to access record data before it was retrieved
+	// from database and SetError(error) called".
 	err = tx.tx.Set(dr, record.Data())
 	if Debugf != nil {
 		Debugf(ctx, "tx.Set(%v) completed in %v, err: %v", key, time.Since(started), err)


### PR DESCRIPTION
## Problem

`transaction.Set`, `database.Set` and `database.SetMulti` call `record.Data()` without first marking the record's error state. A record created with `dal.NewRecordWithData(...)` has its error still `nil`, and `record.Data()` panics in that state:

> an attempt to access record data before it was retrieved from database and SetError(error) called

So **any** `tx.Set(dal.NewRecordWithData(key, &dbo))` panics. This breaks every store write of a fresh record against Firestore — e.g. the sneat `eventus` stores (overlay/event/invitation/link/slot/rsvp) all use exactly that pattern, so creating an event 500s with a panic.

## Fix

The `insert()` path and `transaction.SetMulti` already guard this by calling `record.SetError(nil)` (which maps to `dal.ErrNoError`) before accessing the data. The `Set` paths didn't. This mirrors that guard in all three `Set` paths.

## Test

Adds `Test_DB_Set_does_not_panic_on_fresh_record`, which panics without the fix and passes with it (verified red→green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)